### PR TITLE
Compatible with sqlite3

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -98,7 +98,7 @@ func (a *Adapter) createDatabase() error {
 				return nil
 			}
 		}
-	} else {
+	} else if a.driverName != "sqlite3" {
 		err = db.Exec("CREATE DATABASE IF NOT EXISTS casbin").Error
 	}
 	return err


### PR DESCRIPTION
I create new adapter.
```
gormadapter.NewAdapter("sqlite3", "assets/database.db")
```
After i get panic `near "DATABASE": syntax error`. I think it's happened because connection string connect to database and not server.
I change https://github.com/casbin/gorm-adapter/blob/8e3239544c1cf4bab113bd2311d8d0842086abe8/adapter.go#L101
to `if a.driverName != "sqlite3"` and all is worked.