### PR TITLE
Don't append db name to sqllite when opening connection.

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -128,6 +128,8 @@ func (a *Adapter) open() {
 
 		if a.driverName == "postgres" {
 			db, err = gorm.Open(a.driverName, a.dataSourceName+" dbname=casbin")
+		} else if a.driverName == "sqlite3" {
+			db, err = gorm.Open(a.driverName, a.dataSourceName)
 		} else {
 			db, err = gorm.Open(a.driverName, a.dataSourceName+"casbin")
 		}


### PR DESCRIPTION
This will prevent the following pannic: 

```
panic: SQL logic error [recovered]
	panic: SQL logic error
```
That is caused by appending the db name to the source which triggers the panic on the following line: https://github.com/casbin/gorm-adapter/blob/5f0f4b5ecad7f5259de033c2765c1e9399b23034/adapter.go#L135