### PR TITLE
Support for loading filtered policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
 
 services:
   - mysql
+  - postgresql

--- a/adapter.go
+++ b/adapter.go
@@ -35,15 +35,16 @@ type CasbinRule struct {
 }
 
 type Filter struct {
-	V0 []string
-	V1 []string
-	V2 []string
-	V3 []string
-	V4 []string
-	V5 []string
+	PType []string
+	V0    []string
+	V1    []string
+	V2    []string
+	V3    []string
+	V4    []string
+	V5    []string
 }
 
-func (c *CasbinRule) TableName() string{
+func (c *CasbinRule) TableName() string {
 	return "casbin_rule" //as Gorm keeps table names are plural, and we love consistency
 }
 
@@ -242,7 +243,10 @@ func (a *Adapter) IsFiltered() bool {
 
 // filterQuery builds the gorm query to match the rule filter to use within a scope.
 func (a *Adapter) filterQuery(db *gorm.DB, filter Filter) func(db *gorm.DB) *gorm.DB {
-	return func (db *gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if len(filter.PType) > 0 {
+			db = db.Where("p_type in (?)", filter.PType)
+		}
 		if len(filter.V0) > 0 {
 			db = db.Where("v0 in (?)", filter.V0)
 		}
@@ -338,23 +342,23 @@ func (a *Adapter) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int,
 	line := CasbinRule{}
 
 	line.PType = ptype
-	if fieldIndex <= 0 && 0 < fieldIndex + len(fieldValues) {
-		line.V0 = fieldValues[0 - fieldIndex]
+	if fieldIndex <= 0 && 0 < fieldIndex+len(fieldValues) {
+		line.V0 = fieldValues[0-fieldIndex]
 	}
-	if fieldIndex <= 1 && 1 < fieldIndex + len(fieldValues) {
-		line.V1 = fieldValues[1 - fieldIndex]
+	if fieldIndex <= 1 && 1 < fieldIndex+len(fieldValues) {
+		line.V1 = fieldValues[1-fieldIndex]
 	}
-	if fieldIndex <= 2 && 2 < fieldIndex + len(fieldValues) {
-		line.V2 = fieldValues[2 - fieldIndex]
+	if fieldIndex <= 2 && 2 < fieldIndex+len(fieldValues) {
+		line.V2 = fieldValues[2-fieldIndex]
 	}
-	if fieldIndex <= 3 && 3 < fieldIndex + len(fieldValues) {
-		line.V3 = fieldValues[3 - fieldIndex]
+	if fieldIndex <= 3 && 3 < fieldIndex+len(fieldValues) {
+		line.V3 = fieldValues[3-fieldIndex]
 	}
-	if fieldIndex <= 4 && 4 < fieldIndex + len(fieldValues) {
-		line.V4 = fieldValues[4 - fieldIndex]
+	if fieldIndex <= 4 && 4 < fieldIndex+len(fieldValues) {
+		line.V4 = fieldValues[4-fieldIndex]
 	}
-	if fieldIndex <= 5 && 5 < fieldIndex + len(fieldValues) {
-		line.V5 = fieldValues[5 - fieldIndex]
+	if fieldIndex <= 5 && 5 < fieldIndex+len(fieldValues) {
+		line.V5 = fieldValues[5-fieldIndex]
 	}
 	err := rawDelete(a.db, line)
 	return err

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -162,7 +162,7 @@ func testFilteredPolicy(t *testing.T, a *Adapter) {
 	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
 
 	// Load alice's policy with all five attributes
-	assert.Nil(t, e.LoadFilteredPolicy(Filter{V0: []string{"alice"}, V1: []string{"data"}, V2: []string{"1"}, V3: []string{"2"}, V4: []string{"3"}, V5: []string{"read"}}))
+	assert.Nil(t, e.LoadFilteredPolicy(Filter{PType: []string{"p"}, V0: []string{"alice"}, V1: []string{"data"}, V2: []string{"1"}, V3: []string{"2"}, V4: []string{"3"}, V5: []string{"read"}}))
 	testGetPolicy(t, e, [][]string{{"alice", "data", "1", "2", "3", "read"}})
 }
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -59,7 +59,7 @@ func initPolicy(t *testing.T, a *Adapter) {
 	if err != nil {
 		panic(err)
 	}
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
 }
 
 func testSaveLoad(t *testing.T, a *Adapter) {
@@ -73,7 +73,7 @@ func testSaveLoad(t *testing.T, a *Adapter) {
 	// NewEnforcer() will load the policy automatically.
 
 	e := casbin.NewEnforcer("examples/rbac_model.conf", a)
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
 }
 
 func initAdapter(t *testing.T, driverName string, dataSourceName string, dbSpecified ...bool) *Adapter {
@@ -114,7 +114,7 @@ func testAutoSave(t *testing.T, a *Adapter) {
 	// Reload the policy from the storage to see the effect.
 	e.LoadPolicy()
 	// This is still the original policy.
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
 
 	// Now we enable the AutoSave.
 	e.EnableAutoSave(true)
@@ -125,18 +125,18 @@ func testAutoSave(t *testing.T, a *Adapter) {
 	// Reload the policy from the storage to see the effect.
 	e.LoadPolicy()
 	// The policy has a new rule: {"alice", "data1", "write"}.
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"alice", "data1", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}, {"alice", "data1", "write"}})
 
 	// Remove the added rule.
 	e.RemovePolicy("alice", "data1", "write")
 	e.LoadPolicy()
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
 
 	// Remove "data2_admin" related policy rules via a filter.
 	// Two rules: {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"} are deleted.
 	e.RemoveFilteredPolicy(0, "data2_admin")
 	e.LoadPolicy()
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
 }
 
 func testFilteredPolicy(t *testing.T, a *Adapter) {
@@ -147,7 +147,7 @@ func testFilteredPolicy(t *testing.T, a *Adapter) {
 
 	// Load only alice's policies
 	assert.Nil(t, e.LoadFilteredPolicy(Filter{V0: []string{"alice"}}))
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"alice", "data", "1", "2", "3", "read"}})
 
 	// Load only bob's policies
 	assert.Nil(t, e.LoadFilteredPolicy(Filter{V0: []string{"bob"}}))
@@ -159,7 +159,11 @@ func testFilteredPolicy(t *testing.T, a *Adapter) {
 
 	// Load policies for alice and bob
 	assert.Nil(t, e.LoadFilteredPolicy(Filter{V0: []string{"alice", "bob"}}))
-	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}})
+	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"alice", "data", "1", "2", "3", "read"}})
+
+	// Load alice's policy with all five attributes
+	assert.Nil(t, e.LoadFilteredPolicy(Filter{V0: []string{"alice"}, V1: []string{"data"}, V2: []string{"1"}, V3: []string{"2"}, V4: []string{"3"}, V5: []string{"read"}}))
+	testGetPolicy(t, e, [][]string{{"alice", "data", "1", "2", "3", "read"}})
 }
 
 func TestAdapters(t *testing.T) {

--- a/examples/rbac_policy.csv
+++ b/examples/rbac_policy.csv
@@ -2,4 +2,5 @@ p, alice, data1, read
 p, bob, data2, write
 p, data2_admin, data2, read
 p, data2_admin, data2, write
+p, alice, data, 1, 2, 3, read
 g, alice, data2_admin


### PR DESCRIPTION
**Reason for support:**
In gorm, if you want to use [hooks](http://gorm.io/docs/hooks.html) for enforcing rules with casbin so you get cascading permissions, it's impossible to do so without degradation of performance when the DB grows in size.

Performance degradation occurs due to needing to create a new Enforcer on each callback, as the adaptor needs to be re-created with the db from the callback scope so rules can be added within the same transaction as the callback. This means on each callback, you have to fully load the policy which then tanks performance as your rule set grows.

**Workaround attempts:**
If you add a single Enforcer within the gorm scope to be used throughout each callback, then you hit race conditions with setting of adaptors for concurrent transactions.

If you create a new enforcer with an existing casbin `model.Model` and a new `gormadapter`, then casbin automatically loads all policies.

If you create a new enforcer with just the `model.Model` and then set the adapter after, the policies don't persist between enforcers, giving false negatives on rule enforcement.

**PR Notes:**
Aimed to keep in-line with other filtered adaptors, keeping consistency. Allows the end-user to filter based on all rule attributes, including multiple at any one time.

Rather than creating an issue, I thought I'd just do the work and send it for review as it wasn't much effort.