### PR TITLE
[feature request]: support to create multiple adapters under same database with method `NewAdapterByDBUseTableName`

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -286,12 +286,17 @@ func (a *Adapter) getTableInstance() *CasbinRule {
 	return &CasbinRule{}
 }
 
+func (a *Adapter) getFullTableName() string {
+	if a.tablePrefix != "" {
+		return a.tablePrefix + "_" + a.tableName
+	}
+	return a.tableName
+}
+
 func (a *Adapter) casbinRuleTable() func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
-		if a.tablePrefix != "" {
-			return db.Table(a.tablePrefix + "_" + a.tableName)
-		}
-		return db.Table(a.tableName)
+		tableName := a.getFullTableName()
+		return db.Table(tableName)
 	}
 }
 
@@ -306,10 +311,7 @@ func (a *Adapter) createTable() error {
 		return err
 	}
 
-	tableName := a.tableName
-	if a.tablePrefix != "" {
-		tableName = a.tablePrefix + "_" + tableName
-	}
+	tableName := a.getFullTableName()
 	index := "idx_" + tableName
 	hasIndex := a.db.Migrator().HasIndex(t, index)
 	if !hasIndex {

--- a/adapter.go
+++ b/adapter.go
@@ -17,6 +17,7 @@ package gormadapter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 
@@ -39,13 +40,13 @@ type customTableKey struct{}
 
 type CasbinRule struct {
 	ID    uint   `gorm:"primaryKey;autoIncrement"`
-	Ptype string `gorm:"size:100;uniqueIndex:unique_index"`
-	V0    string `gorm:"size:100;uniqueIndex:unique_index"`
-	V1    string `gorm:"size:100;uniqueIndex:unique_index"`
-	V2    string `gorm:"size:100;uniqueIndex:unique_index"`
-	V3    string `gorm:"size:100;uniqueIndex:unique_index"`
-	V4    string `gorm:"size:100;uniqueIndex:unique_index"`
-	V5    string `gorm:"size:100;uniqueIndex:unique_index"`
+	Ptype string `gorm:"size:100"`
+	V0    string `gorm:"size:100"`
+	V1    string `gorm:"size:100"`
+	V2    string `gorm:"size:100"`
+	V3    string `gorm:"size:100"`
+	V4    string `gorm:"size:100"`
+	V5    string `gorm:"size:100"`
 }
 
 type Filter struct {
@@ -296,11 +297,33 @@ func (a *Adapter) casbinRuleTable() func(db *gorm.DB) *gorm.DB {
 
 func (a *Adapter) createTable() error {
 	t := a.db.Statement.Context.Value(customTableKey{})
+
+	tableName := a.tableName
+	if a.tablePrefix != "" {
+		tableName = a.tablePrefix + "_" + tableName
+	}
+	index := "idx_" + tableName
+
+	hasIndex := false
 	if t == nil {
-		return a.db.AutoMigrate(a.getTableInstance())
+		instance := a.getTableInstance()
+		hasIndex = a.db.Migrator().HasIndex(instance, index)
+		if err := a.db.AutoMigrate(instance); err != nil {
+			return err
+		}
+	} else {
+		hasIndex = a.db.Migrator().HasIndex(t, index)
+		if err := a.db.AutoMigrate(t); err != nil {
+			return err
+		}
 	}
 
-	return a.db.AutoMigrate(t)
+	if !hasIndex {
+		if err := a.db.Exec(fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s (ptype,v0,v1,v2,v3,v4,v5)", index, tableName)).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (a *Adapter) dropTable() error {

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -144,6 +144,18 @@ func initAdapterWithGormInstanceByName(t *testing.T, db *gorm.DB, name string) *
 	return a
 }
 
+func initAdapterWithGormInstanceByPrefixAndName(t *testing.T, db *gorm.DB, prefix, name string) *Adapter {
+	//Create an Adapter
+	a, _ := NewAdapterByDBUseTableName(db, prefix, name)
+	// Initialize some policy in DB.
+	initPolicy(t, a)
+	// Now the DB has policy, so we can provide a normal use case.
+	// Note: you don't need to look at the above code
+	// if you already have a working DB with policy inside.
+
+	return a
+}
+
 //func TestNilField(t *testing.T) {
 //	a, err := NewAdapter("sqlite3", "test.db")
 //	assert.Nil(t, err)
@@ -327,6 +339,13 @@ func TestAdapters(t *testing.T) {
 	testSaveLoad(t, a)
 
 	a = initAdapterWithGormInstanceByName(t, db, "casbin_rule")
+	testFilteredPolicy(t, a)
+
+	a = initAdapterWithGormInstanceByPrefixAndName(t, db, "casbin", "first")
+	testAutoSave(t, a)
+	testSaveLoad(t, a)
+
+	a = initAdapterWithGormInstanceByPrefixAndName(t, db, "casbin", "second")
 	testFilteredPolicy(t, a)
 
 	db, err = gorm.Open(sqlite.Open("casbin.db"), &gorm.Config{})


### PR DESCRIPTION
## User Case:
A scenario is that when multiple adapters will be created under same database with method `NewAdapterByDBUseTableName`, in fact, this will create multiple tables with different name, current codes can't support this because the hard-code gorm uniqueIndex tag `unique_index` on `CasbinRule` will prevent creating unique index for other tables due to index name conflict. This PR is a proposal to support such scenario.
