### PR TITLE
fix: Printing the supported DB name strings in error message

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -219,7 +219,7 @@ func openDBConnection(driverName, dataSourceName string) (*gorm.DB, error) {
 		//} else if driverName == "sqlite3" {
 		//	db, err = gorm.Open(sqlite.Open(dataSourceName), &gorm.Config{})
 	} else {
-		return nil, errors.New("database dialect is not supported")
+		return nil, errors.New("Database dialect '"+driverName+"' is not supported. Supported databases are postgres, mysql and sqlserver")
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Right now from the following documentation user just knows that mysql can be used as the string while connecting to mysql
`	a, _ := gormadapter.NewAdapter("mysql", "mysql_username:mysql_password@tcp(127.0.0.1:3306)/") // Your driver and data source.
`

However if someone wants to use postgres then it is not clear what string should be used. Should that be "pg" or "pgsql" or "postgres" or "postgressql".
I had to navigate the code to find that out. Printing the supported DB name strings in error message so that user knows the valid options to use in  connection string would be helpful and this is what this commit attempts at doing.

So instead of printing 

> `"database dialect is not supported"`

it will print the passed in invalid option as well as the valid option list as follows. Also the first character is made upper case

> `"Database dialect 'pgsql is not supported. Supported databases are postgres, mysql and sqlserver"`
