### PR TITLE
postgresql相比其他数据库多了一个schema(模式),操作表的时候都会有：模式.表名

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -375,7 +375,7 @@ func (a *Adapter) createTable() error {
 	}
 
 	tableName := a.getFullTableName()
-	index := "idx_" + tableName
+	index := strings.ReplaceAll("idx_"+tableName, ".", "_")
 	hasIndex := a.db.Migrator().HasIndex(t, index)
 	if !hasIndex {
 		if err := a.db.Exec(fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s (ptype,v0,v1,v2,v3,v4,v5)", index, tableName)).Error; err != nil {


### PR DESCRIPTION
这样就会导致在创建索引的时候出现如下语法：
CREATE UNIQUE INDEX idxweb.tb_auth_casbin_rule ON web.tb_auth_casbin_rule (ptype,v0,v1,v2,v3,v4,v5)
这种索引名称中还有 点(point)的格式是postgresql语法不支持的。
因此建议替换成下划线（_）