### PR TITLE
fix: PostgreSql create  index occur error

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -375,7 +375,7 @@ func (a *Adapter) createTable() error {
 	}
 
 	tableName := a.getFullTableName()
-	index := "idx_" + tableName
+	index := strings.ReplaceAll("idx_"+tableName, ".", "_")
 	hasIndex := a.db.Migrator().HasIndex(t, index)
 	if !hasIndex {
 		if err := a.db.Exec(fmt.Sprintf("CREATE UNIQUE INDEX %s ON %s (ptype,v0,v1,v2,v3,v4,v5)", index, tableName)).Error; err != nil {


### PR DESCRIPTION
PostgreSQL has one more schema  than other databases. When operating tables, there will be:    schema  . Table name

This will result in the following syntax when creating an index:

```code
CREATE UNIQUE INDEX idxweb.tb_auth_casbin_rule ON web.tb_auth_casbin_ rule (ptype,v0,v1,v2,v3,v4,v5)
```

This format with a point in the index name is not supported by PostgreSQL syntax.
```err

SQL ERROR [42601]: ERROR: syntax error at or near "."

```

Therefore, it is recommended to replace it with an underscore ( _ )