### PR TITLE
Fix the implementation of incorrect table prefix

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -351,7 +351,7 @@ func (a *Adapter) getTableInstance() *CasbinRule {
 
 func (a *Adapter) getFullTableName() string {
 	if a.tablePrefix != "" {
-		return a.tablePrefix + "_" + a.tableName
+		return a.tablePrefix + a.tableName
 	}
 	return a.tableName
 }


### PR DESCRIPTION
We should not assume what the user thinks.
if the prefix is 'hello' and the table name is 'world', the `FullTableName` should be `helloworld` , not `hello_world`.
unless the prefix is `hello_`.
This is also the implementation of gorm.