### PR TITLE
feat: add options allow disable automigrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ func main() {
 	// Initialize a Gorm adapter and use it in a Casbin enforcer:
 	// The adapter will use an existing gorm.DB instnace.
 	a, _ := gormadapter.NewAdapterByDBWithCustomTable(db, &CasbinRule{}) 
+	// Or use NewAdapterByDBUseTableName
+	/*
+	a, _ := gormadapter.NewAdapterByDBUseTableName(db, "{{your_table_prefix}}", "{{your_table_name}}",
+		gormadapter.WithAutoMigrate(false),
+	)
+	*/
 	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
 	
 	// Load the policy from DB.

--- a/options.go
+++ b/options.go
@@ -1,3 +1,17 @@
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gormadapter
 
 type adapterOptions struct {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,19 @@
+package gormadapter
+
+type adapterOptions struct {
+	autoMigrate bool
+}
+
+type Option func(options *adapterOptions)
+
+func defaultAdapterOptions() adapterOptions {
+	return adapterOptions{
+		autoMigrate: true,
+	}
+}
+
+func WithAutoMigrate(autoMigrate bool) Option {
+	return func(o *adapterOptions) {
+		o.autoMigrate = autoMigrate
+	}
+}


### PR DESCRIPTION
background:
gorm-adapter will automigrate table,  this pr will provide some options allow developer disable automigrate feature for some special situation


feature:
1. add adapter options
2. allow disable automigrate