### PR TITLE
fix: added getter for db instance inside adapter

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -444,3 +444,7 @@ func (a *Adapter) rawDelete(db *gorm.DB, line CasbinRule) error {
 	err := db.Delete(a.getTableInstance(), args...).Error
 	return err
 }
+
+func (a *Adapter) getDb() *gorm.DB {
+	return a.db
+}


### PR DESCRIPTION
Added getter for db instance inside adapter. Can you backport this fix to v2.0.3, if possible?

Fix: https://github.com/casbin/gorm-adapter/issues/153