### PR TITLE
fix: empty slice found error

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -577,8 +577,10 @@ func (a *Adapter) SavePolicy(model model.Model) error {
 			}
 		}
 	}
-	if err := a.db.Create(&lines).Error; err != nil {
-		return err
+	if len(lines) > 0 {
+		if err := a.db.Create(&lines).Error; err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
fixed the error occurred when savePolicy is called.


```
github.com/casbin/gorm-adapter/v3@v3.7.1/adapter.go:580 empty slice found
[3.402ms] [rows:0] INSERT INTO `casbin_rule` (`ptype`,`v0`,`v1`,`v2`,`v3`,`v4`,`v5`,`v6`,`v7`) VALUES 
empty slice found
```

