### PR TITLE
feat: support transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,31 @@ func main() {
 	e.SavePolicy()
 }
 ```
+## Transaction
+You can modify policies within a transaction.See example:
+```go
+package main
 
+func main() {
+	a, err := NewAdapterByDB(db)
+	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
+	err = e.GetAdapter().(*Adapter).Transaction(e, func(e casbin.IEnforcer) error {
+		_, err := e.AddPolicy("jack", "data1", "write")
+		if err != nil {
+			return err
+		}
+		_, err = e.AddPolicy("jack", "data2", "write")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		// handle if transaction failed
+		return
+	}
+}
+```
 ## Getting Help
 
 - [Casbin](https://github.com/casbin/casbin)

--- a/adapter.go
+++ b/adapter.go
@@ -19,10 +19,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/casbin/casbin/v2"
 	"runtime"
 	"strings"
 
+	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/casbin/casbin/v2/persist"
 	"github.com/glebarez/sqlite"

--- a/adapter.go
+++ b/adapter.go
@@ -612,14 +612,24 @@ func (a *Adapter) AddPolicies(sec string, ptype string, rules [][]string) error 
 }
 
 // Transaction perform a set of operations within a transaction
-func (a *Adapter) Transaction(e *casbin.Enforcer, fc func(*casbin.Enforcer) error, opts ...*sql.TxOptions) error {
-	tx := a.db.Begin(opts...)
+func (a *Adapter) Transaction(e casbin.IEnforcer, fc func(casbin.IEnforcer) error, opts ...*sql.TxOptions) error {
+	var err error
+	oriAdapter := a.db
+	// reload policy from database to sync with the transaction
+	defer func() {
+		e.SetAdapter(&Adapter{db: oriAdapter})
+		err = e.LoadPolicy()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	copyDB := *a.db
+	tx := copyDB.Begin(opts...)
 	b := &Adapter{db: tx}
 	// copy enforcer to set the new adapter with transaction tx
-	copyE := *e
-	copyEnforcer := &copyE
+	copyEnforcer := e
 	copyEnforcer.SetAdapter(b)
-	err := fc(copyEnforcer)
+	err = fc(copyEnforcer)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/adapter.go
+++ b/adapter.go
@@ -16,6 +16,7 @@ package gormadapter
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"github.com/casbin/casbin/v2"
@@ -611,8 +612,8 @@ func (a *Adapter) AddPolicies(sec string, ptype string, rules [][]string) error 
 }
 
 // Transaction perform a set of operations within a transaction
-func (a *Adapter) Transaction(e *casbin.Enforcer, fc func(*casbin.Enforcer) error) {
-	tx := a.db.Begin()
+func (a *Adapter) Transaction(e *casbin.Enforcer, fc func(*casbin.Enforcer) error, opts ...*sql.TxOptions) {
+	tx := a.db.Begin(opts...)
 	b := &Adapter{db: tx}
 	// copy enforcer to set the new adapter with transaction tx
 	copyE := *e

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -626,3 +626,20 @@ func TestAddPoliciesFullColumn(t *testing.T) {
 
 	testGetPolicy(t, e, [][]string{{"alice", "data1", "read"}, {"bob", "data2", "write"}, {"data2_admin", "data2", "read"}, {"data2_admin", "data2", "write"}, {"jack", "data1", "read", "col3", "col4", "col5", "col6", "col7"}, {"jack2", "data1", "read", "col3", "col4", "col5", "col6", "col7"}})
 }
+
+func TestTransaction(t *testing.T) {
+	a := initAdapter(t, "mysql", "root:@tcp(127.0.0.1:3306)/", "casbin", "casbin_rule")
+	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
+	e.GetAdapter().(*Adapter).Transaction(e, func(e *casbin.Enforcer) error {
+		_, err := e.AddPolicy("jack", "data1", "write")
+		if err != nil {
+			return err
+		}
+		_, err = e.AddPolicy("jack", "data2", "write")
+		//err = errors.New("some error")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -630,7 +630,7 @@ func TestAddPoliciesFullColumn(t *testing.T) {
 func TestTransaction(t *testing.T) {
 	a := initAdapter(t, "mysql", "root:@tcp(127.0.0.1:3306)/", "casbin", "casbin_rule")
 	e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
-	e.GetAdapter().(*Adapter).Transaction(e, func(e *casbin.Enforcer) error {
+	err := e.GetAdapter().(*Adapter).Transaction(e, func(e casbin.IEnforcer) error {
 		_, err := e.AddPolicy("jack", "data1", "write")
 		if err != nil {
 			return err
@@ -642,4 +642,7 @@ func TestTransaction(t *testing.T) {
 		}
 		return nil
 	})
+	if err != nil {
+		return
+	}
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/gorm-adapter/issues/175

support transaction
Example: 
```golang
  a := initAdapter(t, "mysql", "root:@tcp(127.0.0.1:3306)/", "casbin", "casbin_rule")
  e, _ := casbin.NewEnforcer("examples/rbac_model.conf", a)
  e.GetAdapter().(*Adapter).Transaction(e, func(e *casbin.Enforcer) error {
    _, err := e.AddPolicy("jack", "data1", "write")
    if err != nil {
	    return err
    }
    _, err = e.AddPolicy("jack", "data2", "write")
    //err = errors.New("some error")
    if err != nil {
	    return err
    }
    return nil
  })
```