### PR TITLE
feat: upgrade casbin to v2.55.1 and add preview feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/casbin/gorm-adapter/v3
 go 1.14
 
 require (
-	github.com/casbin/casbin/v2 v2.37.4
+	github.com/casbin/casbin/v2 v2.55.1
 	github.com/glebarez/sqlite v1.4.3
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/casbin/casbin/v2 v2.37.4 h1:RWSKPjaZ8JlOBlcW1bI/FTII8OPxvQ9jVy9JwyNL6DQ=
 github.com/casbin/casbin/v2 v2.37.4/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
+github.com/casbin/casbin/v2 v2.55.1 h1:vaTAHSLkQfielg9UiHdIdvIVK/NAmMjBkDkrOM9iDqI=
+github.com/casbin/casbin/v2 v2.55.1/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=


### PR DESCRIPTION
Since Casbin in the latest version has a nice feature, AddPermissionsForUser(), which can add multiple at the same time, I upgraded Casbin to v2.55.1.

Later, when using LoadPolicy(), I always found that the data in the database was not loaded into Casbin and no error was reported. After troubleshooting, I found that it was because loadPolicyLine was not returning an error message.

This error message was caused by a possible conflict in Casbin. In HasPolicyEx() it is required that the policy has 3 fields, otherwise an error message is thrown.

However, when using AddPermissionForUser(), it is possible to pass two parameters.
e.AddPermissionForUser("bob", "read")

So this submission has two main points.
1. Pre-check in LoadPolicy(), and throw an error message in advance if there is an error.
2. Change the Casbin version number in the dependency to v2.55.1.
My English is not good, so I used a translation software, thanks for your patience to read it.