### PR TITLE
feat: New method for creating filtered adapter with existing gorm instance

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -250,6 +250,19 @@ func NewFilteredAdapter(driverName string, dataSourceName string, params ...inte
 	return adapter, err
 }
 
+// NewFilteredAdapterByDB is the constructor for FilteredAdapter.
+// Casbin will not automatically call LoadPolicy() for a filtered adapter.
+func NewFilteredAdapterByDB(db *gorm.DB, prefix string, tableName string) (*Adapter, error) {
+	adapter := &Adapter{
+		tablePrefix: prefix,
+		tableName:   tableName,
+		isFiltered:  true,
+	}
+	adapter.db = db.Scopes(adapter.casbinRuleTable()).Session(&gorm.Session{Context: db.Statement.Context})
+
+	return adapter, nil
+}
+
 // NewAdapterByDB creates gorm-adapter by an existing Gorm instance
 func NewAdapterByDB(db *gorm.DB) (*Adapter, error) {
 	return NewAdapterByDBUseTableName(db, "", defaultTableName)


### PR DESCRIPTION
**Why**

We use casbin filtered adapter on closured level i.e new adapter created on every request instead on global level so that only relevant policies are loaded on every request. But creating a new gorm connection on every request would be not optimised. Hence wanted to expose a new filtered adapter which accepts existing gorm instance.